### PR TITLE
Implement getString, getInt, getBoolean with default value on JacksonObject

### DIFF
--- a/src/main/java/com/github/pgelinas/jackson/javax/json/JacksonObject.java
+++ b/src/main/java/com/github/pgelinas/jackson/javax/json/JacksonObject.java
@@ -60,7 +60,8 @@ public class JacksonObject extends AbstractMap<String, JsonValue> implements Jso
 
     @Override
     public String getString(String name, String defaultValue) {
-        return _delegate.get(name).asText();
+        JsonNode jsonNode = _delegate.get(name);
+        return (jsonNode == null) ? defaultValue : jsonNode.asText();
     }
 
     @Override
@@ -70,7 +71,8 @@ public class JacksonObject extends AbstractMap<String, JsonValue> implements Jso
 
     @Override
     public int getInt(String name, int defaultValue) {
-        return _delegate.get(name).asInt(defaultValue);
+        JsonNode jsonNode = _delegate.get(name);
+        return (jsonNode == null) ? defaultValue : jsonNode.asInt(defaultValue);
     }
 
     @Override
@@ -80,7 +82,8 @@ public class JacksonObject extends AbstractMap<String, JsonValue> implements Jso
 
     @Override
     public boolean getBoolean(String name, boolean defaultValue) {
-        return _delegate.get(name).asBoolean(defaultValue);
+        JsonNode jsonNode = _delegate.get(name);
+        return (jsonNode == null) ? defaultValue : jsonNode.asBoolean(defaultValue);
     }
 
     @Override

--- a/src/test/java/com/github/pgelinas/jackson/javax/json/ReadPropertiesWithDefaultValuesTest.java
+++ b/src/test/java/com/github/pgelinas/jackson/javax/json/ReadPropertiesWithDefaultValuesTest.java
@@ -1,0 +1,33 @@
+package com.github.pgelinas.jackson.javax.json;
+
+import org.junit.Test;
+
+import javax.json.JsonObject;
+import javax.json.spi.JsonProvider;
+import java.io.StringReader;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+public class ReadPropertiesWithDefaultValuesTest {
+
+    private static final JsonProvider PROVIDER = JsonProvider.provider();
+
+    private static final JsonObject EMPTY_JSON_OBJECT = PROVIDER.createReader(new StringReader("{}")).readObject();
+
+    @Test
+    public void getStringPropertyWithDefaultValue() {
+        assertThat(EMPTY_JSON_OBJECT.getString("prop", "default"), equalTo("default"));
+    }
+
+    @Test
+    public void getBooleanPropertyWithDefaultValue() {
+        assertThat(EMPTY_JSON_OBJECT.getBoolean("prop", true), equalTo(true));
+    }
+
+    @Test
+    public void getIntPropertyWithDefaultValue() {
+        assertThat(EMPTY_JSON_OBJECT.getInt("prop", 100), equalTo(100));
+    }
+
+}


### PR DESCRIPTION
Previously, if the property was not present on the object a NullPointerException would be thrown.
This differed from the reference implementation where the provided default value would be returned, instead.

Fixes #6 
