### PR TITLE
Fix bug with JacksonObject#getString(String, String) and null values

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ dependencies {
 }
 
 group = "com.github.pgelinas"
-version = "1.0.0"
+version = "1.0.1"
 
 release {
   tagTemplate = 'v${version}'

--- a/src/main/java/com/github/pgelinas/jackson/javax/json/JacksonObject.java
+++ b/src/main/java/com/github/pgelinas/jackson/javax/json/JacksonObject.java
@@ -61,7 +61,11 @@ public class JacksonObject extends AbstractMap<String, JsonValue> implements Jso
     @Override
     public String getString(String name, String defaultValue) {
         JsonNode jsonNode = _delegate.get(name);
-        return (jsonNode == null) ? defaultValue : jsonNode.asText();
+        if(jsonNode == null) {
+            return defaultValue;
+        } else {
+            return jsonNode.isNull() ? defaultValue : jsonNode.asText();
+        }
     }
 
     @Override
@@ -72,7 +76,11 @@ public class JacksonObject extends AbstractMap<String, JsonValue> implements Jso
     @Override
     public int getInt(String name, int defaultValue) {
         JsonNode jsonNode = _delegate.get(name);
-        return (jsonNode == null) ? defaultValue : jsonNode.asInt(defaultValue);
+        if(jsonNode == null) {
+            return defaultValue;
+        } else {
+            return jsonNode.isNull() ? defaultValue : jsonNode.asInt(defaultValue);
+        }
     }
 
     @Override
@@ -83,7 +91,11 @@ public class JacksonObject extends AbstractMap<String, JsonValue> implements Jso
     @Override
     public boolean getBoolean(String name, boolean defaultValue) {
         JsonNode jsonNode = _delegate.get(name);
-        return (jsonNode == null) ? defaultValue : jsonNode.asBoolean(defaultValue);
+        if(jsonNode == null) {
+            return defaultValue;
+        } else {
+            return jsonNode.isNull() ? defaultValue : jsonNode.asBoolean(defaultValue);
+        }
     }
 
     @Override

--- a/src/test/java/com/github/pgelinas/jackson/javax/json/ReadPropertiesWithDefaultValuesTest.java
+++ b/src/test/java/com/github/pgelinas/jackson/javax/json/ReadPropertiesWithDefaultValuesTest.java
@@ -15,6 +15,8 @@ public class ReadPropertiesWithDefaultValuesTest {
 
     private static final JsonObject EMPTY_JSON_OBJECT = PROVIDER.createReader(new StringReader("{}")).readObject();
 
+    private static final JsonObject JSON_OBJECT_WITH_NULL_VALUE = PROVIDER.createReader(new StringReader("{ \"foo\": null }")).readObject();
+
     @Test
     public void getStringPropertyWithDefaultValue() {
         assertThat(EMPTY_JSON_OBJECT.getString("prop", "default"), equalTo("default"));
@@ -30,4 +32,18 @@ public class ReadPropertiesWithDefaultValuesTest {
         assertThat(EMPTY_JSON_OBJECT.getInt("prop", 100), equalTo(100));
     }
 
+    @Test
+    public void getNullValueStringPropertyWithDefaultValue() {
+        assertThat(JSON_OBJECT_WITH_NULL_VALUE.getString("foo", "bar"), equalTo("bar"));
+    }
+
+    @Test
+    public void getNullValueBooleanPropertyWithDefaultValue() {
+        assertThat(JSON_OBJECT_WITH_NULL_VALUE.getBoolean("foo", true), equalTo(true));
+    }
+
+    @Test
+    public void getNullValueIntPropertyWithDefaultValue() {
+        assertThat(JSON_OBJECT_WITH_NULL_VALUE.getInt("foo", 1), equalTo(1));
+    }
 }


### PR DESCRIPTION
In JSR 353, the JsonObject#getString(String name, String defaultValue)
method returns defaultValue if the value associated with name in the
source JSON is null, e.g. { "foo": null }.  In this implementation,
the call to _delegate#get returns a NullNode instead of the value
null, which means the return value is NullNode#asText (i.e. the literal
string "null") instead of the default value.

This is fixed by modifying the equivalent method in JacksonObject
so that we check the value of JsonNode#isNull if the null check
passes, and return the default value if isNull returns true.
Although getInt(String, int) and getBoolean(String, boolean)
work correctly in this case because of how asInt and asBoolean are
implemented, the fix is applied to those methods as well.

It's possible that this could have been fixed by simply calling
JsonNode#asText(defaultValue), but that method isn't available
in the version of Jackson used by this project (it was added in 2.4).